### PR TITLE
Room Metadata Support

### DIFF
--- a/examples/minimal/demo/connection_menu/connection_manager.gd
+++ b/examples/minimal/demo/connection_menu/connection_manager.gd
@@ -7,6 +7,9 @@ extends VBoxContainer
 func _on_host_pressed() -> void:
 	await Multiplayer.setup_connection(room_region.selected)
 	Multiplayer.nt_peer.host_room(true, "")
+	print(Multiplayer.nt_peer.room_id)
+	await Multiplayer.nt_peer.room_connected
+	print(Multiplayer.nt_peer.room_id)
 
 func _on_join_pressed() -> void:
 	var id = room_id_in.text

--- a/examples/minimal/demo/connection_menu/connection_manager.gd
+++ b/examples/minimal/demo/connection_menu/connection_manager.gd
@@ -6,7 +6,7 @@ extends VBoxContainer
 
 func _on_host_pressed() -> void:
 	await Multiplayer.setup_connection(room_region.selected)
-	Multiplayer.nt_peer.host_room(true, room_name.text, 4)
+	Multiplayer.nt_peer.host_room(true, "")
 
 func _on_join_pressed() -> void:
 	var id = room_id_in.text

--- a/examples/minimal/demo/multiplayer.gd
+++ b/examples/minimal/demo/multiplayer.gd
@@ -20,8 +20,15 @@ func setup_connection(relay_idx: int):
 	await nt_peer.authenticated
 	print("authenticated")
 
+func update_room_metadata():
+	nt_peer.update_room("players: 1")
+
 func get_relay_addr(prefix: String) -> String:
 	for relay in RELAYS:
 		if relay["prefix"] == prefix:
 			return relay["addr"]
 	return ""
+
+func _process(delta: float) -> void:
+	if Input.is_action_just_pressed("ui_right"):
+		update_room_metadata()

--- a/src/src/lib.rs
+++ b/src/src/lib.rs
@@ -1,6 +1,6 @@
 mod node_tunnel_peer;
 mod relay_client;
-mod protocol;
+pub mod protocol;
 mod transport;
 
 use godot::prelude::*;

--- a/src/src/node_tunnel_peer.rs
+++ b/src/src/node_tunnel_peer.rs
@@ -82,8 +82,8 @@ impl NodeTunnelPeer {
     }
 
     #[func]
-    fn host_room(&mut self, public: bool, display_name: String, max_players: i32) -> Error {
-        match self.relay_client.req_create_room(public, display_name, max_players) {
+    fn host_room(&mut self, public: bool, metadata: String) -> Error {
+        match self.relay_client.req_create_room(public, metadata) {
             Ok(_) => Error::OK,
             Err(e) => {
                 godot_error!("[NodeTunnel] Failed to create room: {}", e);
@@ -137,9 +137,7 @@ impl NodeTunnelPeer {
                 for room in rooms {
                     let mut room_dict = Dictionary::new();
                     room_dict.set("id", room.id.clone());
-                    room_dict.set("name", room.name.clone());
-                    room_dict.set("players", room.players);
-                    room_dict.set("max_players", room.max_players);
+                    room_dict.set("metadata", room.metadata.clone());
 
                     room_array.push(&room_dict.to_variant());
                 }

--- a/src/src/protocol/ids.rs
+++ b/src/src/protocol/ids.rs
@@ -10,3 +10,4 @@ pub const FORCE_DISCONNECT: u8 = 8;
 pub const ERROR_PACKET: u8 = 9;
 pub const REQ_ROOMS: u8 = 10;
 pub const GET_ROOMS: u8 = 11;
+pub const UPDATE_ROOM: u8 = 12;

--- a/src/src/protocol/packet.rs
+++ b/src/src/protocol/packet.rs
@@ -15,6 +15,7 @@ pub enum PacketType {
     CreateRoom { is_public: bool, metadata: String },
     ReqRooms,
     GetRooms { rooms: Vec<RoomInfo> },
+    UpdateRoom { room_id: String, metadata: String },
     JoinRoom { room_id: String },
     ConnectedToRoom { room_id: String, peer_id: i32 },
     PeerJoinedRoom { peer_id: i32 },
@@ -97,6 +98,12 @@ impl PacketType {
                 PacketType::GetRooms { rooms }
             }
 
+            UPDATE_ROOM => {
+                let (room_id, r) = read_string(rest)?;
+                let (metadata, _) = read_string(r)?;
+                PacketType::UpdateRoom { room_id, metadata }
+            }
+
             _ => return Err(ProtocolError::UnknownPacketType(packet_id))
         })
     }
@@ -128,6 +135,12 @@ impl PacketType {
             PacketType::GetRooms { rooms } => {
                 buf.push(GET_ROOMS);
                 push_vec_room_info(&mut buf, rooms);
+            }
+
+            PacketType::UpdateRoom { room_id, metadata } => {
+                buf.push(UPDATE_ROOM);
+                push_string(&mut buf, room_id);
+                push_string(&mut buf, metadata);
             }
 
             PacketType::JoinRoom { room_id } => {

--- a/src/src/protocol/packet.rs
+++ b/src/src/protocol/packet.rs
@@ -5,16 +5,14 @@ use crate::protocol::serialize::{push_bool, push_i32, push_string, push_vec_room
 #[derive(Debug, Clone)]
 pub struct RoomInfo {
     pub id: String,
-    pub name: String,
-    pub players: i32,
-    pub max_players: i32,
+    pub metadata: String,
 }
 
 #[derive(Debug, Clone)]
 pub enum PacketType {
     Authenticate { app_id: String, version: String },
     ClientAuthenticated,
-    CreateRoom { is_public: bool, name: String, max_players: i32 },
+    CreateRoom { is_public: bool, metadata: String },
     ReqRooms,
     GetRooms { rooms: Vec<RoomInfo> },
     JoinRoom { room_id: String },
@@ -46,8 +44,7 @@ impl PacketType {
 
             CREATE_ROOM => {
                 let (is_public, r) = read_bool(rest)?;
-                let (max_players, r) = read_i32(r)?;
-                let name = match read_string(r) {
+                let metadata = match read_string(r) {
                     Ok((name, _)) => {
                         name
                     }
@@ -56,7 +53,7 @@ impl PacketType {
                     }
                 };
 
-                PacketType::CreateRoom { is_public, name, max_players }
+                PacketType::CreateRoom { is_public, metadata }
             },
 
             JOIN_ROOM => {
@@ -118,11 +115,10 @@ impl PacketType {
                 buf.push(CLIENT_AUTHENTICATED);
             }
 
-            PacketType::CreateRoom { is_public, name, max_players } => {
+            PacketType::CreateRoom { is_public, metadata } => {
                 buf.push(CREATE_ROOM);
                 push_bool(&mut buf, *is_public);
-                push_i32(&mut buf, *max_players);
-                push_string(&mut buf, name);
+                push_string(&mut buf, metadata);
             }
 
             PacketType::ReqRooms => {

--- a/src/src/protocol/version.rs
+++ b/src/src/protocol/version.rs
@@ -1,3 +1,1 @@
-// This version does not always match the plugin version
-// It's only changed when the protocol changes
 pub const PROTOCOL_VERSION: &str = "1.1.0_beta";

--- a/src/src/relay_client/client.rs
+++ b/src/src/relay_client/client.rs
@@ -119,12 +119,11 @@ impl RelayClient {
         Ok(())
     }
 
-    pub fn req_create_room(&mut self, is_public: bool, name: String, max_players: i32) -> Result<(), RelayClientError> {
+    pub fn req_create_room(&mut self, is_public: bool, metadata: String) -> Result<(), RelayClientError> {
         self.send_packet(
             PacketType::CreateRoom {
                 is_public,
-                name,
-                max_players
+                metadata,
             },
             Channel::Reliable
         )?;

--- a/src/src/relay_client/client.rs
+++ b/src/src/relay_client/client.rs
@@ -147,6 +147,15 @@ impl RelayClient {
         Ok(())
     }
 
+    pub fn req_update_room(&mut self, room_id: &str, metadata: &str) -> Result<(), RelayClientError> {
+        self.send_packet(
+            PacketType::UpdateRoom { room_id: room_id.to_string(), metadata: metadata.to_string() },
+            Channel::Reliable
+        )?;
+
+        Ok(())
+    }
+
     pub fn send_game_data(&mut self, peer_id: i32, data: Vec<u8>, channel: Channel) -> Result<(), RelayClientError> {
         self.send_packet(
             PacketType::GameData { from_peer: peer_id, data },


### PR DESCRIPTION
This adds support for a new `metadata` field on rooms. This allows rooms to be created with custom information and replaces `max_players` and `display_name` fields. Metadata is a string with a max size of 1kb, and can be used to attach info to rooms such as mods, players, display name, etc.

**New Changes**
- Add room metadata
- Add `update_room(metadata)` function to allow for updating room data after creation (player count, display name, etc.)
- `room_id` is now stored in `NodeTunnelPeer`

**Breaking Changes**
- `host_room` now only takes in 2 parameters: `is_public` and `metadata`. `max_players` and `display_name` have been replaced with `metadata`. It is now up to the developer to maintain these if they wish to do so.
- `NodeTunnelPeer.room_connected` no longer returns `room_id`, and must be accessed using `NodeTunnelPeer.room_id` instead.